### PR TITLE
Allow to work with more than just gulp-gzip

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.14.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,13 @@ const PluginError = gutil.PluginError;
 function getMetadata(file, extraMetadata = {}) {
   const meta = {
     ...extraMetadata,
-    contentType: mime.lookup(file.path),
+    contentType: mime.lookup(file.path.replace(/\.gz$/, '')),
   };
 
-  // Check if it's gziped
-  if (file.contentEncoding && file.contentEncoding.indexOf('gzip') > -1) {
+  // Check to see if it has a gz (Gzip) extension
+  if (file.extname == '.gz') {
     meta.contentEncoding = 'gzip';
-  }
+  };
 
   return meta;
 }
@@ -144,7 +144,6 @@ function gPublish(options) {
       return done(null, file);
     }
 
-    file.path = file.path.replace(/\.gz$/, '');
     const metadata = getMetadata(file, extraMetadata);
 
     // Authenticate on Google Cloud Storage

--- a/test/gcloud.spec.js
+++ b/test/gcloud.spec.js
@@ -96,7 +96,7 @@ describe('gulp-gcloud-publish', function suite() {
     .on('error', done);
   });
 
-  it('should recognise a gzip and make it public', function test(done) {
+  it('should recognise a gzip and set contentEncoding', function test(done) {
     createWriteStreamStub.returns(createFakeStream());
     const fakeFile = new File({
       contents: es.readArray(['stream', 'with', 'those', 'contents']),
@@ -104,8 +104,6 @@ describe('gulp-gcloud-publish', function suite() {
       base: '/test/',
       path: '/test/file.css.gz',
     });
-
-    fakeFile.contentEncoding = ['gzip'];
 
     const config = _.clone(exampleConfig);
     config.public = true;
@@ -120,7 +118,6 @@ describe('gulp-gcloud-publish', function suite() {
         contentEncoding: 'gzip',
       });
 
-      assert.ifError(/\.gz$/.test(file.path));
       done();
     })
     .on('error', done);


### PR DESCRIPTION
The gzip recognition was based on a property that `gulp-gzip` sets. For
those who use `gulp-zopfli` the contentEncoding was not being set.

Now, we simply rely on the file extension to tell if it's gzipped or
not.
